### PR TITLE
Fixed typo in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OmniAuth ConstantContact
+# OmniAuth Fitbit Strategy
 
 This gem is an OmniAuth 1.0+ Strategy for the [Fitbit API](https://wiki.fitbit.com/display/API/OAuth+Authentication+in+the+Fitbit+API).
 


### PR DESCRIPTION
I noticed that there's no 'omniauth-fitbit' gem on rubygems.org; are you planning to release this as a gem or should users refer directly to the git repo from the Gemfile?
