### PR TITLE
Making the auth hash schema provide the required [info][name] field

### DIFF
--- a/lib/omniauth/strategies/fitbit.rb
+++ b/lib/omniauth/strategies/fitbit.rb
@@ -20,6 +20,7 @@ module OmniAuth
 
       info do
         {
+            :name         => raw_info['user']['displayName'],
             :full_name    => raw_info['user']['fullName'],
             :display_name => raw_info['user']['displayName'],
             :nickname     => raw_info['user']['nickname'],

--- a/spec/omniauth/strategies/fitbit_spec.rb
+++ b/spec/omniauth/strategies/fitbit_spec.rb
@@ -57,6 +57,10 @@ describe "OmniAuth::Strategies::Fitbit" do
         } 
       }
     end
+    
+    it 'returns the correct name from raw_info' do
+      subject.info[:name].should eq("JD")
+    end
 
     it 'returns the correct full name from raw_info' do
       subject.info[:full_name].should eq("John Doe")


### PR DESCRIPTION
According to https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema the schema of the auth hash should include ["info"]["name"]. I just used the display_name, since it seemed to fit the description.

> `name` (required) - The best display name known to the strategy. Usually a concatenation of first and last name, but may also be an arbitrary designator or nickname for some strategies
