### PR TITLE
Added option to retrieve Fitbit profile measurements in English units.

### DIFF
--- a/lib/omniauth/strategies/fitbit.rb
+++ b/lib/omniauth/strategies/fitbit.rb
@@ -43,7 +43,11 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= MultiJson.load(access_token.get('http://api.fitbit.com/1/user/-/profile.json').body)
+        if options[:use_english_measure] == 'true'
+          @raw_info ||= MultiJson.load(access_token.request('get', 'http://api.fitbit.com/1/user/-/profile.json', { 'Accept-Language' => 'en_US' }).body)
+        else
+          @raw_info ||= MultiJson.load(access_token.get('http://api.fitbit.com/1/user/-/profile.json').body)
+        end
       end
     end
   end


### PR DESCRIPTION
By default, Fitbit responds to api-get-user-info (profile) calls with values for height and weight in metric units. This change allows a developer to request English units. Example:

``` ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :fitbit, 'consumer', 'secret', { :use_english_measure => 'true' }
end
```
