### PR TITLE
Add scope paramter to middlewear stack in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+With OAuth 2.0, the additional URI parameter  of 'scope' (a space-delimited list of the permissions you are requesting) is required, and should be included in the strategy as well.
+
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :fitbit, 'consumer_key', 'consumer_secret', scope: "activity profile"
+end
+```
+
 To register your application with Fitbit and obtain a consumer key and secret, go to the [Fitbit application registration](https://dev.fitbit.com/apps/new).
 
 For additional information about OmniAuth, visit [OmniAuth wiki](https://github.com/intridea/omniauth/wiki).


### PR DESCRIPTION
In OAuth 2.0, Fitbit is requiring the additional parameter of scope in its request, in addition to client_id and client_token.  This PR adds to the README file this additional parameter. 