### PR TITLE
Allow 'prompt' oauth attribute for Fitbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-With OAuth 2.0, the additional URI parameter  of 'scope' (a space-delimited list of the permissions you are requesting) is required, and should be included in the strategy as well.
+With OAuth 2.0, the additional URI parameter  of 'scope' (a space-delimited list of the permissions you are requesting) is required, and should be included in the strategy as well. The URI paramater of 'prompt' is also allowed. Specify if you need to force the Fitbit authentication or the OAuth 2.0 authorization page to be displayed. When used, the redirect_uri parameter must be specified.
 
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :fitbit, 'consumer_key', 'consumer_secret', scope: "activity profile"
+  provider :fitbit, 'consumer_key', 'consumer_secret', scope: "activity profile", prompt: "login consent"
 end
 ```
 

--- a/lib/omniauth/strategies/fitbit.rb
+++ b/lib/omniauth/strategies/fitbit.rb
@@ -13,7 +13,7 @@ module OmniAuth
       }
 
       option :response_type, 'code'
-      option :authorize_options, %i(scope response_type redirect_uri)
+      option :authorize_options, %i(scope response_type redirect_uri prompt)
 
       def build_access_token
         options.token_params.merge!(:headers => {'Authorization' => basic_auth_header })

--- a/spec/omniauth/strategies/fitbit_spec.rb
+++ b/spec/omniauth/strategies/fitbit_spec.rb
@@ -16,6 +16,10 @@ describe "OmniAuth::Strategies::Fitbit" do
       expect(subject.options["authorize_options"]).to include(:scope)
     end
 
+    it 'includes :prompt' do
+      expect(subject.options["authorize_options"]).to include(:prompt)
+    end
+
     it 'includes :response_type' do
       expect(subject.options["authorize_options"]).to include(:response_type)
     end


### PR DESCRIPTION
This would allow the 'prompt' attribute.

Documented by Fitbit:

Specify if you need to force the Fitbit authentication or the OAuth 2.0 authorization page to be displayed. When used, the redirect_uri parameter must be specified.

none for default behavior.
consent to require consent from the user, even if they have previously authorized your application.
login to require the user to sign in, but request consent according to the default behavior.
login consent to require the user to sign in and authorize your application.
Optional
Type: string